### PR TITLE
Fix package

### DIFF
--- a/contextual-pkg.el
+++ b/contextual-pkg.el
@@ -1,2 +1,0 @@
-(define-package "contextual" "0.1.0" "Contextual profile management system"
-  '((dash "2.12.1")))

--- a/contextual.el
+++ b/contextual.el
@@ -4,7 +4,7 @@
 
 ;; Author: Alexander Kahl <alex@lshift.de>
 ;; Version: 0.1.0
-;; Package-Requires: ((dash "2.12.1"))
+;; Package-Requires: ((emacs "24") (dash "2.12.1") (cl-lib "0.5"))
 ;; Keywords: convenience, tools
 ;; URL: https://github.com/lshift-de/contextual
 
@@ -29,7 +29,7 @@
 
 ;;; Code:
 
-(require 'cl-macs)
+(require 'cl-lib)
 (require 'dash)
 
 ;;; Types and customization


### PR DESCRIPTION
- Fix dependencies for older Emacs
  - cl-lib.el should be loaded rather than cl-macs.el. Because cl-macs.el was bundled since Emacs 24.3.
- Remove package file because it is duplicated with package header of contextual.el.

2nd fix can remove `:files` attribute from MELPA recipe(https://github.com/milkypostman/melpa/pull/3516).
